### PR TITLE
Upgrade log4j from 2.10.0 to 2.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The API consists of all public Kotlin types from `com.atlassian.performance.tool
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/concurrency/compare/release-1.1.0...master
 
+### Fixed
+- Bump log4j to `2.17.1`. Address JPERF-772.
+
+[JPERF-772]: https://ecosystem.atlassian.net/browse/JPERF-772
+
 ## [1.1.0] - 2019-07-31
 [1.1.0]: https://github.com/atlassian/concurrency/compare/release-1.0.0...release-1.1.0
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 val kotlinVersion = "1.2.70"
+val log4jVersion = "2.17.1"
 
 plugins {
     kotlin("jvm").version("1.2.70")
@@ -9,6 +10,15 @@ configurations.all {
     resolutionStrategy {
         activateDependencyLocking()
         failOnVersionConflict()
+        eachDependency {
+            when (requested.module.toString()) {
+                "org.slf4j:slf4j-api" -> useVersion("1.8.0-alpha2")
+            }
+            when (requested.group) {
+                "org.apache.logging.log4j" -> useVersion(log4jVersion)
+                "org.jetbrains.kotlin" -> useVersion(kotlinVersion)
+            }
+        }
     }
 }
 
@@ -27,7 +37,7 @@ dependencies {
 fun log4j(
     vararg modules: String
 ): List<String> = modules.map { module ->
-    "org.apache.logging.log4j:log4j-$module:2.10.0"
+    "org.apache.logging.log4j:log4j-$module:$log4jVersion"
 }
 
 tasks.getByName("wrapper", Wrapper::class).apply {

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,9 +2,9 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:jvm-tasks:1.0.1
-org.apache.logging.log4j:log4j-api:2.10.0
-org.apache.logging.log4j:log4j-core:2.10.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.10.0
+org.apache.logging.log4j:log4j-api:2.17.1
+org.apache.logging.log4j:log4j-core:2.17.1
+org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70


### PR DESCRIPTION
 * Keep slf4j-api resolving to 1.8.0-alpha2, although there is a separate log4j binding for slf4j 1.8+ now