### PR TITLE
JPERF-902: Apply axion-release plugin's instructions to CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -34,17 +31,32 @@ jobs:
       with:
         name: test-reports
         path: build/reports/tests
-
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    needs: build
+    if: github.event.inputs.release == 'yes'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Cache Gradle
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle
+        key: ${{ runner.os }}-${{ hashFiles('gradle') }}
     - name: Get publish token
       id: publish-token
-      if: github.event.inputs.release == 'yes'
       uses: atlassian-labs/artifact-publish-token@v1.0.1
-
     - name: Release
-      if: github.event.inputs.release == 'yes'
       env:
         atlassian_private_username: ${{ steps.publish-token.outputs.artifactoryUsername }}
         atlassian_private_password: ${{ steps.publish-token.outputs.artifactoryApiKey }}
       run: |
-        ./gradlew release -Prelease.customUsername=${{ secrets.REPOSITORY_ACCESS_TOKEN }}
+        ./gradlew release \
+            -Prelease.customUsername=${{ github.actor }} \
+            -Prelease.customPassword=${{ github.token }}
         ./gradlew publish


### PR DESCRIPTION
The release CI in the current form requires up-to-date credentials stored in the GitHub's secrets feature of the repository. Tokens are generated for limited amount of time and need to be updated manually. This requires knowledge maintenance and is doomed to fail at some point.

We are using the mentioned credentials (token) in `axion-release` gradle plugin. This plugin is dependency of `gradle-release` gradle plugin developed by us. It is used to create git tags of releases.

With `axion-release` it's possible to reuse github automated mechanisms to authenticate git client operations. The way to do that is documented in https://axion-release-plugin.readthedocs.io/en/latest/configuration/ci_servers/#github-actions

In order to make the `github.token` work for git client mutable operations like pushing tags we need permission `contents: write` for the CI job.

The approach was inspired by already tested [ci.yml from `report` module](https://github.com/atlassian/report/blob/769530e8acfe14e9b22a2e945d1dedae5a51db38/.github/workflows/ci.yml)

I decided to not grant `contents: write` permission to the rest of the CI (tests), so I extracted the `release` job. This way tests are now using the default permissions defined on the repository level.